### PR TITLE
Added on-demand session token refresh

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -120,8 +120,13 @@ class SessionRefresh(MiddlewareMixin):
             LOGGER.debug("request is not refreshable")
             return
 
-        expiration = request.session.get("oidc_id_token_expiration", 0)
         now = time.time()
+
+        if hasattr(request, 'headers') and 'X-Refresh-OIDC-Token' in request.headers:
+            request.session['oidc_id_token_expiration'] = now
+
+        expiration = request.session.get("oidc_id_token_expiration", 0)
+
         if expiration > now:
             # The id_token is still valid, so we don't have to do anything.
             LOGGER.debug("id token is still valid (%s > %s)", expiration, now)


### PR DESCRIPTION
Added a special case that allows AJAX queries to refresh the session on demand.  AJAX queries simply need to add the
header 'X-Refresh-OIDC-Token' to the request and it will reset the session expiration so it generates a reauth redirect. This allows SPAs and other Javascript driven applications to proactively control session refresh.