### PR TITLE
Do not set oidc_login_next for AJAX 403 redirects

### DIFF
--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -154,8 +154,6 @@ class SessionRefresh(MiddlewareMixin):
 
         add_state_and_verifier_and_nonce_to_session(request, state, params)
 
-        request.session["oidc_login_next"] = request.get_full_path()
-
         query = urlencode(params, quote_via=quote)
         redirect_url = "{url}?{query}".format(url=auth_url, query=query)
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
@@ -170,4 +168,6 @@ class SessionRefresh(MiddlewareMixin):
             response = JsonResponse({"refresh_url": redirect_url}, status=403)
             response["refresh_url"] = redirect_url
             return response
+
+        request.session["oidc_login_next"] = request.get_full_path()
         return HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
Moved the oidc_login_next to below the AJAX return, this means AJAX requests will be redirected to the LOGIN_REDIRECT_URL instead of the API endpoint that generated the session refresh.